### PR TITLE
feat: MapData 카드 뷰 페이징 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,13 +26,13 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.data:spring-data-commons'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
     annotationProcessor 'org.projectlombok:lombok'
-
     //swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 

--- a/src/main/java/com/yogo/metacraft/mapdata/document/MapDataCardDto.java
+++ b/src/main/java/com/yogo/metacraft/mapdata/document/MapDataCardDto.java
@@ -1,0 +1,18 @@
+package com.yogo.metacraft.mapdata.document;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MapDataCardDto {
+    private String id;
+    private String mapName;
+    private String thumbnail;
+
+    public MapDataCardDto(MapData mapData) {
+        this.id = mapData.getId();
+        this.mapName = mapData.getMapName();
+        this.thumbnail = mapData.getThumbnail();
+    }
+}

--- a/src/main/java/com/yogo/metacraft/mapdata/document/PageResponseDto.java
+++ b/src/main/java/com/yogo/metacraft/mapdata/document/PageResponseDto.java
@@ -1,0 +1,27 @@
+package com.yogo.metacraft.mapdata.document;
+
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+public class PageResponseDto<T> {
+    private List<T> content;
+    private int pageNumber;
+    private int pageSize;
+    private long totalElements;
+    private int totalPages;
+    private boolean first;
+    private boolean last;
+
+    public PageResponseDto(Page<T> page) {
+        this.content = page.getContent();
+        this.pageNumber = page.getNumber();
+        this.pageSize = page.getSize();
+        this.totalElements = page.getTotalElements();
+        this.totalPages = page.getTotalPages();
+        this.first = page.isFirst();
+        this.last = page.isLast();
+    }
+}

--- a/src/main/java/com/yogo/metacraft/mapdata/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/yogo/metacraft/mapdata/exception/GlobalExceptionHandler.java
@@ -1,0 +1,39 @@
+package com.yogo.metacraft.mapdata.exception;
+
+
+import com.yogo.metacraft.common.CustomApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(InvalidSortParameterException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<CustomApiResponse<Void>> handleInvalidSortParameterException(InvalidSortParameterException e) {
+        return ResponseEntity
+                .badRequest()
+                .body(new CustomApiResponse<>(false, "Invalid sort parameters: " + e.getMessage()));
+    }
+
+    @ExceptionHandler(MapDataException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ResponseEntity<CustomApiResponse<Void>> handleMapDataException(MapDataException e) {
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new CustomApiResponse<>(false, "MapData exception: " + e.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ResponseEntity<CustomApiResponse<Void>> handleGlobalException(Exception e) {
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new CustomApiResponse<>(false, "An unexpected error occurredL: " + e.getMessage()));
+    }
+
+
+}

--- a/src/main/java/com/yogo/metacraft/mapdata/exception/InvalidSortParameterException.java
+++ b/src/main/java/com/yogo/metacraft/mapdata/exception/InvalidSortParameterException.java
@@ -1,0 +1,7 @@
+package com.yogo.metacraft.mapdata.exception;
+
+public class InvalidSortParameterException extends MapDataException{
+    public InvalidSortParameterException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/yogo/metacraft/mapdata/exception/MapDataException.java
+++ b/src/main/java/com/yogo/metacraft/mapdata/exception/MapDataException.java
@@ -1,0 +1,7 @@
+package com.yogo.metacraft.mapdata.exception;
+
+public class MapDataException extends RuntimeException {
+    public MapDataException(String message) {
+        super(message);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: 12450
+  port: 12452
 
 spring:
   servlet:


### PR DESCRIPTION
- MapData 조회 시 instanceData를 제외한 카드 뷰 API 추가
- 페이지네이션, 정렬 기능 구현
- Page 직렬화 문제 해결을 위한 PageResponseDto 도입

상세 변경사항:
- build.gradle: spring-data-commons 의존성 추가
- MapDataController: 카드 뷰 조회 API (/api/map/cards) 엔드포인트 추가
- 페이징 처리를 위한 관련 클래스 import 추가
- 서버 포트 변경 (12450 → 12452)